### PR TITLE
Add household invite feature

### DIFF
--- a/src/api/services/invitesService.ts
+++ b/src/api/services/invitesService.ts
@@ -1,0 +1,28 @@
+import { api } from '../client';
+import type {
+  CreateInviteDto,
+  InviteResponseDto,
+  UserResponseDto,
+} from '../types';
+
+export const invitesService = {
+  createInvite: (data: CreateInviteDto): Promise<InviteResponseDto> => {
+    return api.post<InviteResponseDto>('/invites', data);
+  },
+
+  getPendingInvites: (): Promise<InviteResponseDto[]> => {
+    return api.get<InviteResponseDto[]>('/invites/pending');
+  },
+
+  acceptInvite: (inviteId: string): Promise<void> => {
+    return api.post<void>(`/invites/${inviteId}/accept`);
+  },
+
+  rejectInvite: (inviteId: string): Promise<void> => {
+    return api.post<void>(`/invites/${inviteId}/reject`);
+  },
+
+  getUsers: (): Promise<UserResponseDto[]> => {
+    return api.get<UserResponseDto[]>('/users');
+  },
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -128,6 +128,21 @@ export interface RegistryResponseDto {
   createdAt: string;
 }
 
+// Invite DTOs
+export interface CreateInviteDto {
+  invitedUserIds: string[];
+  householdId: string;
+}
+
+export interface InviteResponseDto {
+  id: string;
+  fromUser: UserResponseDto;
+  invitedUserIds: string[];
+  householdId: string;
+  householdName: string;
+  createdAt: string;
+}
+
 // Registry query parameters
 export type RegistryDateFilter =
   | 'today'

--- a/src/hooks/mutations/index.ts
+++ b/src/hooks/mutations/index.ts
@@ -20,3 +20,9 @@ export {
   useCreateRegistryEntryMutation,
   useCreateBatchRegistryMutation,
 } from './useRegistryMutations';
+
+export {
+  useCreateInviteMutation,
+  useAcceptInviteMutation,
+  useRejectInviteMutation,
+} from './useInviteMutations';

--- a/src/hooks/mutations/useInviteMutations.test.ts
+++ b/src/hooks/mutations/useInviteMutations.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  useCreateInviteMutation,
+  useAcceptInviteMutation,
+  useRejectInviteMutation,
+} from './useInviteMutations';
+import { createTestQueryClient, createWrapper } from '../../test/utils';
+import type { InviteResponseDto } from '../../api/types';
+
+vi.mock('../../api/services/invitesService', () => ({
+  invitesService: {
+    createInvite: vi.fn(),
+    acceptInvite: vi.fn(),
+    rejectInvite: vi.fn(),
+    getPendingInvites: vi.fn(),
+    getUsers: vi.fn(),
+  },
+}));
+
+import { invitesService } from '../../api/services/invitesService';
+
+const mockInvite: InviteResponseDto = {
+  id: 'invite1',
+  fromUser: {
+    id: 'user1',
+    uid: 'user1',
+    displayName: 'Test User',
+    email: 'test@example.com',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+  },
+  invitedUserIds: ['user2', 'user3'],
+  householdId: 'household1',
+  householdName: 'Test Household',
+  createdAt: '2024-01-01',
+};
+
+describe('useCreateInviteMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create an invite and invalidate pending invites', async () => {
+    vi.mocked(invitesService.createInvite).mockResolvedValue(mockInvite);
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const inviteData = {
+      invitedUserIds: ['user2', 'user3'],
+      householdId: 'household1',
+    };
+    result.current.mutate(inviteData);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invitesService.createInvite).toHaveBeenCalledWith(inviteData);
+    expect(invitesService.createInvite).toHaveBeenCalledTimes(1);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['invites', 'pending'],
+    });
+  });
+
+  it('should handle errors when creating invite fails', async () => {
+    const error = new Error('Failed to create invite');
+    vi.mocked(invitesService.createInvite).mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useCreateInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      invitedUserIds: ['user2'],
+      householdId: 'household1',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useAcceptInviteMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should accept an invite and invalidate invites and households', async () => {
+    vi.mocked(invitesService.acceptInvite).mockResolvedValue(undefined);
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAcceptInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate('invite1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invitesService.acceptInvite).toHaveBeenCalledWith('invite1');
+    expect(invitesService.acceptInvite).toHaveBeenCalledTimes(1);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['invites', 'pending'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['households', 'list'],
+    });
+  });
+
+  it('should handle errors when accepting invite fails', async () => {
+    const error = new Error('Failed to accept invite');
+    vi.mocked(invitesService.acceptInvite).mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useAcceptInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate('invite1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useRejectInviteMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject an invite and invalidate pending invites', async () => {
+    vi.mocked(invitesService.rejectInvite).mockResolvedValue(undefined);
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRejectInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate('invite1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invitesService.rejectInvite).toHaveBeenCalledWith('invite1');
+    expect(invitesService.rejectInvite).toHaveBeenCalledTimes(1);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['invites', 'pending'],
+    });
+  });
+
+  it('should handle errors when rejecting invite fails', async () => {
+    const error = new Error('Failed to reject invite');
+    vi.mocked(invitesService.rejectInvite).mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useRejectInviteMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate('invite1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});

--- a/src/hooks/mutations/useInviteMutations.ts
+++ b/src/hooks/mutations/useInviteMutations.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { invitesService } from '../../api/services/invitesService';
+import { queryKeys } from '../../lib/queryKeys';
+import type { CreateInviteDto } from '../../api/types';
+
+export function useCreateInviteMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateInviteDto) => invitesService.createInvite(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.invites.pending(),
+      });
+    },
+  });
+}
+
+export function useAcceptInviteMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inviteId: string) => invitesService.acceptInvite(inviteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.invites.pending(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.households.lists(),
+      });
+    },
+  });
+}
+
+export function useRejectInviteMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inviteId: string) => invitesService.rejectInvite(inviteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.invites.pending(),
+      });
+    },
+  });
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -2,3 +2,4 @@ export { useHouseholdsQuery, useHouseholdQuery } from './useHouseholdsQuery';
 export { useCategoriesQuery, useCategoryQuery } from './useCategoriesQuery';
 export { useChoresQuery, useChoreQuery } from './useChoresQuery';
 export { useRegistryQuery, useRegistryForUserQuery, useRegistryViewQuery } from './useRegistryQuery';
+export { usePendingInvitesQuery, useUsersQuery } from './useInvitesQuery';

--- a/src/hooks/queries/useInvitesQuery.test.ts
+++ b/src/hooks/queries/useInvitesQuery.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePendingInvitesQuery, useUsersQuery } from './useInvitesQuery';
+import { createTestQueryClient, createWrapper } from '../../test/utils';
+import type { InviteResponseDto, UserResponseDto } from '../../api/types';
+
+vi.mock('../../api/services/invitesService', () => ({
+  invitesService: {
+    createInvite: vi.fn(),
+    acceptInvite: vi.fn(),
+    rejectInvite: vi.fn(),
+    getPendingInvites: vi.fn(),
+    getUsers: vi.fn(),
+  },
+}));
+
+import { invitesService } from '../../api/services/invitesService';
+
+describe('usePendingInvitesQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch pending invites', async () => {
+    const mockInvites: InviteResponseDto[] = [
+      {
+        id: 'invite1',
+        fromUser: {
+          id: 'user1',
+          uid: 'user1',
+          displayName: 'Alice',
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-01',
+        },
+        invitedUserIds: ['user2'],
+        householdId: 'household1',
+        householdName: 'Alice House',
+        createdAt: '2024-01-01',
+      },
+    ];
+
+    vi.mocked(invitesService.getPendingInvites).mockResolvedValue(mockInvites);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => usePendingInvitesQuery(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockInvites);
+    expect(invitesService.getPendingInvites).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle errors when fetching pending invites fails', async () => {
+    const error = new Error('Failed to fetch invites');
+    vi.mocked(invitesService.getPendingInvites).mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => usePendingInvitesQuery(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useUsersQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch users list', async () => {
+    const mockUsers: UserResponseDto[] = [
+      {
+        id: 'user1',
+        uid: 'user1',
+        displayName: 'Alice',
+        email: 'alice@example.com',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      },
+      {
+        id: 'user2',
+        uid: 'user2',
+        displayName: 'Bob',
+        email: 'bob@example.com',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      },
+    ];
+
+    vi.mocked(invitesService.getUsers).mockResolvedValue(mockUsers);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useUsersQuery(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockUsers);
+    expect(invitesService.getUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle errors when fetching users fails', async () => {
+    const error = new Error('Failed to fetch users');
+    vi.mocked(invitesService.getUsers).mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useUsersQuery(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});

--- a/src/hooks/queries/useInvitesQuery.ts
+++ b/src/hooks/queries/useInvitesQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { invitesService } from '../../api/services/invitesService';
+import { queryKeys } from '../../lib/queryKeys';
+
+export function usePendingInvitesQuery() {
+  return useQuery({
+    queryKey: queryKeys.invites.pending(),
+    queryFn: () => invitesService.getPendingInvites(),
+  });
+}
+
+export function useUsersQuery() {
+  return useQuery({
+    queryKey: queryKeys.users.list(),
+    queryFn: () => invitesService.getUsers(),
+  });
+}

--- a/src/layout/components/PendingInvitesDialog/index.tsx
+++ b/src/layout/components/PendingInvitesDialog/index.tsx
@@ -1,0 +1,118 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { usePendingInvitesQuery } from '../../../hooks/queries';
+import {
+  useAcceptInviteMutation,
+  useRejectInviteMutation,
+} from '../../../hooks/mutations';
+import { useToast } from '../../../components/ToastProvider/hooks';
+import type { InviteResponseDto } from '../../../api/types';
+
+export interface PendingInvitesDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const PendingInvitesDialog: React.FC<PendingInvitesDialogProps> = ({
+  open,
+  onClose,
+}) => {
+  const { notify } = useToast();
+  const { data: invites, isLoading } = usePendingInvitesQuery();
+  const acceptMutation = useAcceptInviteMutation();
+  const rejectMutation = useRejectInviteMutation();
+
+  const handleAccept = (invite: InviteResponseDto) => {
+    acceptMutation.mutate(invite.id, {
+      onSuccess: () => {
+        notify.success(`Joined ${invite.householdName}`);
+      },
+      onError: (err) => {
+        notify.error('Failed to accept invite');
+        console.error('Failed to accept invite', err);
+      },
+    });
+  };
+
+  const handleReject = (invite: InviteResponseDto) => {
+    rejectMutation.mutate(invite.id, {
+      onSuccess: () => {
+        notify.success('Invite declined');
+      },
+      onError: (err) => {
+        notify.error('Failed to decline invite');
+        console.error('Failed to decline invite', err);
+      },
+    });
+  };
+
+  const pendingInvites = invites ?? [];
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Pending Invites</DialogTitle>
+      <DialogContent>
+        {isLoading ? (
+          <CircularProgress sx={{ display: 'block', mx: 'auto', my: 3 }} />
+        ) : pendingInvites.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 2 }}>
+            No pending invites.
+          </Typography>
+        ) : (
+          <List disablePadding>
+            {pendingInvites.map((invite, index) => (
+              <Box key={invite.id}>
+                {index > 0 && <Divider />}
+                <ListItem
+                  sx={{ px: 0, py: 2 }}
+                  secondaryAction={
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        onClick={() => handleReject(invite)}
+                        disabled={rejectMutation.isPending}
+                      >
+                        Decline
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="contained"
+                        onClick={() => handleAccept(invite)}
+                        disabled={acceptMutation.isPending}
+                      >
+                        Accept
+                      </Button>
+                    </Box>
+                  }
+                >
+                  <ListItemAvatar>
+                    <Avatar src={invite.fromUser.photoURL} />
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={invite.householdName}
+                    secondary={`Invited by ${invite.fromUser.displayName || 'Unknown'}`}
+                  />
+                </ListItem>
+              </Box>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/layout/components/UserAvatar/index.tsx
+++ b/src/layout/components/UserAvatar/index.tsx
@@ -1,11 +1,17 @@
-import { Avatar, IconButton, Menu, MenuItem } from "@mui/material";
-import React from "react";
-import { useAuth } from "../../../authentication/AuthContext/hooks";
+import { Avatar, Badge, IconButton, Menu, MenuItem } from '@mui/material';
+import React, { useState } from 'react';
+import { useAuth } from '../../../authentication/AuthContext/hooks';
+import { usePendingInvitesQuery } from '../../../hooks/queries';
+import { PendingInvitesDialog } from '../PendingInvitesDialog';
 
 export const UserAvatar: React.FC = () => {
   const { user, logout } = useAuth();
+  const { data: pendingInvites } = usePendingInvitesQuery();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [invitesDialogOpen, setInvitesDialogOpen] = useState(false);
   const open = Boolean(anchorEl);
+
+  const inviteCount = pendingInvites?.length ?? 0;
 
   const handleUserMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -18,12 +24,22 @@ export const UserAvatar: React.FC = () => {
   const handleCopyUserId = () => {
     if (user) navigator.clipboard.writeText(user.uid);
     setAnchorEl(null);
-  }
+  };
+
+  const handleOpenInvites = () => {
+    setAnchorEl(null);
+    setInvitesDialogOpen(true);
+  };
 
   return (
     <>
       <IconButton color="inherit" onClick={handleUserMenuClick}>
-        <Avatar sx={{ width: 32, height: 32, bgcolor: 'secondary.main' }} src={user?.photoURL || ''} />
+        <Badge badgeContent={inviteCount} color="error">
+          <Avatar
+            sx={{ width: 32, height: 32, bgcolor: 'secondary.main' }}
+            src={user?.photoURL || ''}
+          />
+        </Badge>
       </IconButton>
       <Menu
         id="basic-menu"
@@ -36,9 +52,16 @@ export const UserAvatar: React.FC = () => {
           },
         }}
       >
+        <MenuItem onClick={handleOpenInvites}>
+          Pending Invites{inviteCount > 0 ? ` (${inviteCount})` : ''}
+        </MenuItem>
         <MenuItem onClick={handleCopyUserId}>Copy user ID</MenuItem>
         <MenuItem onClick={logout}>Logout</MenuItem>
       </Menu>
+      <PendingInvitesDialog
+        open={invitesDialogOpen}
+        onClose={() => setInvitesDialogOpen(false)}
+      />
     </>
-  )
+  );
 };

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -32,6 +32,18 @@ export const queryKeys = {
       [...queryKeys.chores.details(), householdId, id] as const,
   },
 
+  // Invites
+  invites: {
+    all: ['invites'] as const,
+    pending: () => [...queryKeys.invites.all, 'pending'] as const,
+  },
+
+  // Users
+  users: {
+    all: ['users'] as const,
+    list: () => [...queryKeys.users.all, 'list'] as const,
+  },
+
   // Registry
   registry: {
     all: ['registry'] as const,

--- a/src/pages/Households/components/InviteMemberDialog/index.tsx
+++ b/src/pages/Households/components/InviteMemberDialog/index.tsx
@@ -1,35 +1,104 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from "@mui/material";
-import { useState } from "react";
+import {
+  Avatar,
+  Button,
+  Checkbox,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useUsersQuery } from '../../../../hooks/queries';
+import type { UserResponseDto } from '../../../../api/types';
 
 export interface InviteMemberDialogProps {
   open: boolean;
+  existingMemberIds: string[];
   onClose: () => void;
-  onSave: (value: string) => void;
+  onSave: (userIds: string[]) => void;
 }
 
-export const InviteMemberDialog: React.FC<InviteMemberDialogProps> = ({ onSave, onClose, open }) => {
-  const [memberId, setMemberId] = useState('');
+export const InviteMemberDialog: React.FC<InviteMemberDialogProps> = ({
+  open,
+  existingMemberIds,
+  onClose,
+  onSave,
+}) => {
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const { data: users, isLoading } = useUsersQuery();
+
+  const availableUsers = (users ?? []).filter(
+    (user: UserResponseDto) => !existingMemberIds.includes(user.uid)
+  );
+
+  const handleToggle = (userId: string) => {
+    setSelectedUserIds((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  };
 
   const handleClose = () => {
+    setSelectedUserIds([]);
     onClose();
   };
-  
+
   const handleSave = () => {
-    onSave(memberId);
-  }
+    onSave(selectedUserIds);
+    setSelectedUserIds([]);
+  };
 
   return (
-    <Dialog onClose={handleClose} open={open}>
-      <DialogTitle>Invite member</DialogTitle>
+    <Dialog onClose={handleClose} open={open} fullWidth maxWidth="sm">
+      <DialogTitle>Invite Members</DialogTitle>
       <DialogContent>
-        <TextField id="name" label="Member Id" variant="outlined" value={memberId} onChange={(e) => setMemberId(e.target.value)} />
+        {isLoading ? (
+          <CircularProgress sx={{ display: 'block', mx: 'auto', my: 3 }} />
+        ) : availableUsers.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 2 }}>
+            No users available to invite.
+          </Typography>
+        ) : (
+          <List disablePadding>
+            {availableUsers.map((user: UserResponseDto) => (
+              <ListItem key={user.uid} disablePadding>
+                <ListItemButton onClick={() => handleToggle(user.uid)} dense>
+                  <Checkbox
+                    edge="start"
+                    checked={selectedUserIds.includes(user.uid)}
+                    tabIndex={-1}
+                    disableRipple
+                  />
+                  <ListItemAvatar>
+                    <Avatar src={user.photoURL} sx={{ width: 32, height: 32 }} />
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={user.displayName || user.email || user.uid}
+                  />
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleSave}>
-          Save
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={selectedUserIds.length === 0}
+        >
+          Send Invite{selectedUserIds.length > 1 ? 's' : ''}
         </Button>
       </DialogActions>
     </Dialog>
   );
-}
+};

--- a/src/pages/Households/components/Members/index.tsx
+++ b/src/pages/Households/components/Members/index.tsx
@@ -1,28 +1,41 @@
-import { Avatar, Box, Button, Card, CardContent, Chip, Divider, List, ListItem, ListItemAvatar, ListItemText, Typography } from "@mui/material";
-import { useState } from "react";
-import type { HouseholdDoc } from "../../../../types/firestore";
-import { InviteMemberDialog } from "../InviteMemberDialog";
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import type { HouseholdDoc } from '../../../../types/firestore';
+import { InviteMemberDialog } from '../InviteMemberDialog';
 
 export interface MembersProps {
   household: HouseholdDoc;
-  onAddMember: (memberId: string) => void;
+  onInviteMembers: (userIds: string[]) => void;
 }
 
-export const Members: React.FC<MembersProps> = ({ household, onAddMember }) => {
+export const Members: React.FC<MembersProps> = ({ household, onInviteMembers }) => {
   const [openInviteDialog, setOpenInviteDialog] = useState(false);
 
   const handleOpenInviteDialog = () => {
     setOpenInviteDialog(true);
-  }
+  };
 
   const handleInviteMemberClose = () => {
     setOpenInviteDialog(false);
-  }
-  
-  const handleInviteMemberSave = (memberId: string) => {
+  };
+
+  const handleInviteMemberSave = (userIds: string[]) => {
     setOpenInviteDialog(false);
-    onAddMember(memberId)
-  }
+    onInviteMembers(userIds);
+  };
 
   return (
     <Card sx={{ mb: 4 }}>
@@ -37,8 +50,18 @@ export const Members: React.FC<MembersProps> = ({ household, onAddMember }) => {
         >
           <Typography variant="h6">Members</Typography>
           <Box>
-            <Button sx={{mr: 2}} size="small" variant="outlined" onClick={handleOpenInviteDialog}>Invite</Button>
-            <Chip label={`${household?.memberIds.length ?? 0} members`} size="small" />
+            <Button
+              sx={{ mr: 2 }}
+              size="small"
+              variant="outlined"
+              onClick={handleOpenInviteDialog}
+            >
+              Invite
+            </Button>
+            <Chip
+              label={`${household?.memberIds.length ?? 0} members`}
+              size="small"
+            />
           </Box>
         </Box>
 
@@ -58,7 +81,9 @@ export const Members: React.FC<MembersProps> = ({ household, onAddMember }) => {
               </ListItemAvatar>
               <ListItemText
                 primary={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Box
+                    sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                  >
                     <span>{member.displayName}</span>
                   </Box>
                 }
@@ -69,9 +94,10 @@ export const Members: React.FC<MembersProps> = ({ household, onAddMember }) => {
       </CardContent>
       <InviteMemberDialog
         open={openInviteDialog}
+        existingMemberIds={household.memberIds}
         onClose={handleInviteMemberClose}
         onSave={handleInviteMemberSave}
       />
     </Card>
   );
-}
+};

--- a/src/pages/Households/index.tsx
+++ b/src/pages/Households/index.tsx
@@ -6,7 +6,8 @@ import { JoinHouseholdDialog } from "./components/JoinHouseholdDialog";
 import {
   useCreateHouseholdMutation,
   useUpdateHouseholdMutation,
-  useAddHouseholdMemberMutation
+  useAddHouseholdMemberMutation,
+  useCreateInviteMutation,
 } from "../../hooks/mutations";
 import { Edit, Home, Add, GroupAdd, ContentCopy } from "@mui/icons-material";
 import { Members } from "./components/Members";
@@ -21,6 +22,7 @@ export const HouseholdPage: React.FC = () => {
   const createHouseholdMutation = useCreateHouseholdMutation();
   const updateHouseholdMutation = useUpdateHouseholdMutation();
   const addHouseholdMemberMutation = useAddHouseholdMemberMutation();
+  const createInviteMutation = useCreateInviteMutation();
 
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
   const [isEditDialog, setIsEditDialog] = useState<boolean>(false);
@@ -45,18 +47,20 @@ export const HouseholdPage: React.FC = () => {
     );
   }
 
-  function handleAddMember(memberId: string) {
+  function handleInviteMembers(userIds: string[]) {
     if (!household) return;
 
-    addHouseholdMemberMutation.mutate(
-      { householdId: household.id, userId: memberId },
+    createInviteMutation.mutate(
+      { invitedUserIds: userIds, householdId: household.id },
       {
         onSuccess: () => {
-          notify.success('Member added');
+          notify.success(
+            userIds.length === 1 ? 'Invite sent' : `${userIds.length} invites sent`
+          );
         },
         onError: (err) => {
-          notify.error('Failed to add user');
-          console.error("Failed to add user", err);
+          notify.error('Failed to send invite');
+          console.error('Failed to send invite', err);
         },
       }
     );
@@ -186,7 +190,7 @@ export const HouseholdPage: React.FC = () => {
               </CardContent>
             </Card>
 
-            <Members household={household} onAddMember={handleAddMember} />
+            <Members household={household} onInviteMembers={handleInviteMembers} />
           </> : <>
             <Box sx={{
               display: 'flex',


### PR DESCRIPTION
## Summary
- Implement invite system: users can select members from a list to invite to their household
- Add pending invites menu in user profile (top-right avatar) with accept/decline actions
- Badge on avatar shows count of pending invites
- New API service, query hooks, and mutation hooks for invites
- 10 new tests covering all invite mutations and queries (36 total passing)

Closes #2

## Backend API endpoints required
| Method | Endpoint | Purpose |
|--------|----------|---------|
| `POST` | `/invites` | Create invite with `{ invitedUserIds, householdId }` |
| `GET` | `/invites/pending` | Get pending invites for current user |
| `POST` | `/invites/:id/accept` | Accept invite (adds user to household, deletes invite) |
| `POST` | `/invites/:id/reject` | Reject invite (deletes invite) |
| `GET` | `/users` | List all users (for selection in invite dialog) |

## Test plan
- [ ] Verify invite dialog shows user list (excluding existing members)
- [ ] Verify selecting users and sending invites calls correct API
- [ ] Verify pending invites badge appears on avatar when invites exist
- [ ] Verify accepting an invite adds user to household and removes invite
- [ ] Verify declining an invite removes it from the list
- [ ] All 36 unit tests pass